### PR TITLE
Fix mermaid diagram rendering in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # printable-markdown
 Allows you to paste in markdown text and have it rendered and use your browser to print or export it to pdf
+
+# Dev
+
+To run a local web server use
+```sh
+python3 -m http.server 8000
+`

--- a/index.html
+++ b/index.html
@@ -9,6 +9,14 @@
     <!-- Include highlight.js for code syntax highlighting -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.3.1/styles/github.min.css">
     <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.3.1/highlight.min.js"></script>
+    <script>
+        hljs.initHighlightingOnLoad();
+    </script>
+    <!-- Include mermaid.js for diagram support -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@8.13.8/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({ startOnLoad: true });
+    </script>
     <style>
         :root {
             --dark-bg: #1e1e1e;
@@ -258,10 +266,10 @@
             // Configure marked options
             marked.setOptions({
                 highlight: function(code, lang) {
-                    if (lang && hljs.getLanguage(lang)) {
+                    if (typeof hljs !== 'undefined' && lang && hljs.getLanguage(lang)) {
                         return hljs.highlight(code, { language: lang }).value;
                     }
-                    return hljs.highlightAuto(code).value;
+                    return typeof hljs !== 'undefined' ? hljs.highlightAuto(code).value : code;
                 },
                 breaks: true,
                 gfm: true
@@ -271,6 +279,20 @@
             function renderMarkdown() {
                 const markdown = markdownInput.value;
                 markdownOutput.innerHTML = marked.parse(markdown);
+                renderMermaidDiagrams();
+            }
+
+            // Function to render mermaid diagrams
+            function renderMermaidDiagrams() {
+                const mermaidElements = document.querySelectorAll('.language-mermaid');
+                mermaidElements.forEach((element) => {
+                    const code = element.textContent;
+                    const container = document.createElement('div');
+                    container.classList.add('mermaid');
+                    container.innerHTML = code;
+                    element.parentNode.replaceChild(container, element);
+                    mermaid.init(undefined, container);
+                });
             }
 
             // Event listeners


### PR DESCRIPTION
Fixes #1
Fixes #2 

Fix the error 'Uncaught ReferenceError: hljs is not defined' when rendering large markdown and add support for mermaid diagrams.

* **Initialize highlight.js**
  - Add `hljs.initHighlightingOnLoad();` after including the `highlight.js` library in `index.html`.
  - Add a check to ensure `hljs` is defined before using it in the `marked.setOptions` function.

* **Add mermaid.js support**
  - Include the mermaid.js library in `index.html`.
  - Initialize mermaid by adding `mermaid.initialize({ startOnLoad: true });`.
  - Add a function to render mermaid diagrams after rendering markdown.

* **Update README.md**
  - Add instructions to run a local web server using `python3 -m http.server 8000`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joelmnz/printable-markdown/pull/3?shareId=f84e8f6b-2a74-4e72-9d96-40cf26cd6913).